### PR TITLE
Encrypt TLS between ELB and Fargate instances

### DIFF
--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -106,8 +106,8 @@ Resources:
       GroupDescription: Security group for NGINX container
       SecurityGroupIngress:
         - IpProtocol: tcp
-          FromPort: 80
-          ToPort: 80
+          FromPort: 443
+          ToPort: 443
           SourceSecurityGroupId: !GetAtt 
             - LoadBalancerSecurityGroup
             - GroupId
@@ -225,14 +225,16 @@ Resources:
                 history -c;
                 export CONJUR_DATA_KEY=$( echo -n $CONJUR_KEY | base64);
                 export DATABASE_URL="postgres://conjur:${ConjurDBPassword}@${DBEndpoint}:${DBPort}/postgres";
-                conjurctl server &
+                mkdir -p /puma;
+                openssl req -x509 -newkey rsa:4096 -keyout /puma/key.pem -out /puma/cert.pem -days 365 -subj "/CN=conjur" -nodes;
+                conjurctl server --port 443 --bind "ssl://0.0.0.0:443?key=/puma/key.pem\&cert=/puma/cert.pem" &
                 conjurctl wait;
                 AdminApiKey="$(conjurctl account create conjur | awk -F': ' '/^API/{print $2}')";
-                curl --request PUT --data "${ConjurAdminPassword}" --user "admin:${AdminApiKey}" localhost/authn/conjur/password;
+                curl -k --request PUT --data "${ConjurAdminPassword}" --user "admin:${AdminApiKey}" https://localhost/authn/conjur/password;
                 sleep infinity
           PortMappings:
-            - ContainerPort: 80
-              HostPort: 80
+            - ContainerPort: 443
+              HostPort: 443
           LogConfiguration:
             LogDriver: awslogs
             Options:
@@ -287,7 +289,7 @@ Resources:
             - !Ref PublicSubnet2
       LoadBalancers:
         - ContainerName: ConjurContainer
-          ContainerPort: 80
+          ContainerPort: 443
           TargetGroupArn: !Ref TargetGroup
   VpcId:
     Type: 'AWS::EC2::VPC'
@@ -426,13 +428,13 @@ Resources:
     Properties:
       HealthCheckIntervalSeconds: 20
       HealthCheckPath: /
-      HealthCheckProtocol: HTTP
+      HealthCheckProtocol: HTTPS
       HealthCheckTimeoutSeconds: 5
       HealthyThresholdCount: 3
       TargetType: ip
       Name: ConjurTG
-      Port: 80
-      Protocol: HTTP
+      Port: 443
+      Protocol: HTTPS
       UnhealthyThresholdCount: 3
       VpcId: !Ref VpcId
   LoadBalancer:


### PR DESCRIPTION
From AWS documentation:
`The load balancer establishes TLS connections with the targets using
certificates that you install on the targets. The load balancer does
not validate these certificates. Therefore, you can use self-signed
certificates or certificates that have expired. Because the load
balancer is in a virtual private cloud (VPC), traffic between the load
balancer and the targets is authenticated at the packet level, so it is
not at risk of man-in-the-middle attacks or spoofing even if the
certificates on the targets are not valid.`

There are other attack vectors but they can be made very difficult to
achieve via policy.

### What does this PR do?
- Enables encrypted TLS, however, there is no SSL validation. Please see comment above.

### What ticket does this PR close?
#5 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation
