### PR TITLE
Production Ready DB Config

### DIFF
--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -496,11 +496,13 @@ Resources:
       Priority: 1
   ConjurDB:
     Type: 'AWS::RDS::DBInstance'
+    DeletionPolicy: Snapshot
     Properties:
       DBName: !Ref 'AWS::StackName'
       Engine: postgres
       EngineVersion: 10.15
       AllocatedStorage: 20
+      StorageType: gp2
       DBInstanceClass: db.t3.medium
       MasterUsername: conjur
       MasterUserPassword: !Join
@@ -511,6 +513,9 @@ Resources:
       DBSubnetGroupName: !Ref DBSubnetGroup
       VPCSecurityGroups:
         - !Ref PostgresSecurityGroup
+      BackupRetentionPeriod: 14
+      AutoMinorVersionUpgrade: false
+      DeleteAutomatedBackups: false
   LogGroup:
     Type: 'AWS::Logs::LogGroup'
     Properties:


### PR DESCRIPTION
Make some changes to the RDS resource to make it more production ready.
* Increase backup retention from 1 day to 14 days
* Take a snapshot on deletion of RDS instance
* Don't delete backups when deleting the RDS instance
* Disable automatic version bumps
* Upgrade from magnetic to solid state storage