### PR TITLE
Harden aws policy of fargate-execution-role

### DIFF
--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -133,8 +133,12 @@ Resources:
         Version: 2012-10-17
         Statement:
           - Effect: Allow
-            Action: '*'
-            Resource: '*'
+            Action:
+              - 'secretsmanager:GetSecretValue'
+            Resource:
+              - !Ref ConjurAdminPasswordARN
+              - !Ref ConjurDBPassword
+              - !Ref ConjurDataKey
       Roles:
         - !Ref FargateExecutionRole
   FargateExecutionRole:


### PR DESCRIPTION
The basic permissions needed to write to logs and pull images is given
by `arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy`.
The only other permissions needed, was to give access to some secrets.

The rest of the permissions are given to the role that deploys the cluster. 

### What does this PR do?
Improves the policy given to fargate-execution-role

### What ticket does this PR close?
Resolves #[relevant GitHub issues, eg 76]

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation
