### PR TITLE
Allow short branch names

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
     }
     stage('Smoke Test'){
       environment {
-        STACK_NAME = "ecsdeployci${BRANCH_NAME.replaceAll("[^A-Za-z0-9]", "")[0..5]}${BUILD_NUMBER}"
+        STACK_NAME = "ecsdeployci${BRANCH_NAME.replaceAll("[^A-Za-z0-9]", "").take(6)}${BUILD_NUMBER}"
       }
       steps {
         sh 'summon -f scripts/secrets.yml scripts/prepare'


### PR DESCRIPTION
The branch name is used in the stack name, but only the first 6
characters to prevent the stack name becoming too long.

Unfortunately the current code fails if the branch name isn't at least
6 characters long.

This commit allows short branch names (Eg main) by using `take`
rather than slicing to truncate the string.