### PR TITLE
Don't write CI Conjur password to disk

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,9 +23,7 @@ pipeline {
       steps {
         sh 'summon -f scripts/secrets.yml scripts/prepare'
         sh 'summon -f scripts/secrets.yml scripts/deploy'
-        // Summon not needed for exercise as it only uses the conjur api
-        // not the AWS api
-        sh 'scripts/exercise'
+        sh 'summon -f scripts/secrets.yml scripts/exercise'
       }
       post {
         always {

--- a/scripts/exercise
+++ b/scripts/exercise
@@ -11,16 +11,7 @@ TEST_VAR="TestPolicy/TestVariable"
 TEST_VAR_VALUE_1="$(uuidgen)"
 TEST_VAR_VALUE_2="$(uuidgen)"
 DOMAIN_NAME="${DOMAIN_NAME:-ci.conjur.net}" # Doesn't include this stack's subdomain
-
-# Verify Inputs
-if [[ -z "${STACK_NAME}" ]]; then
-  bl_die "STACK_NAME must be set before running ${0}"
-fi
-if [[ ! -r conjur_admin_password ]];  then
-  bl_die "Cannot open file conjur_admin_password"
-fi
-
-ADMIN_PASSWORD="$(< conjur_admin_password)"
+ADMIN_PASSWORD_METADATA_FILE="admin_password_meta.json"
 
 # Functions
 
@@ -46,7 +37,27 @@ check_variable_value(){
   fi
 }
 
+# Retrieve conjur admin password from AWS Secrets Manager
+get_admin_password(){
+  local ADMIN_PASSWORD_ARN
+  # This file created by scripts/prepare
+  ADMIN_PASSWORD_ARN="$(jq -r .ARN < "${ADMIN_PASSWORD_METADATA_FILE}" )"
+  aws secretsmanager get-secret-value \
+    --secret-id "${ADMIN_PASSWORD_ARN}" \
+    --output json \
+    | jq -r '.SecretString'
+}
+
 # Main flow
+
+# Verify Inputs
+if [[ -z "${STACK_NAME}" ]]; then
+  bl_die "STACK_NAME must be set before running ${0}"
+fi
+if [[ ! -r "${ADMIN_PASSWORD_METADATA_FILE}" ]];  then
+  bl_die "Cannot open file ${ADMIN_PASSWORD_METADATA_FILE}, did you run scripts/prepare?"
+fi
+
 mkdir -p cli_root
 
 # Configure CLI if not already configured.
@@ -54,7 +65,7 @@ if [[ ! -e cli_root/conjur-conjur.pem ]]; then
   echo -e "yes\nconjur" |dconjur init -u "https://${STACK_NAME}.${DOMAIN_NAME}"
   set +x +o history
   echo "dconjur authn login -u admin -p \"***\""
-  dconjur authn login -u admin -p "${ADMIN_PASSWORD}"
+  dconjur authn login -u admin -p "$(get_admin_password)"
   set -x
   echo "Conjur CLI Configured"
 else

--- a/scripts/prepare
+++ b/scripts/prepare
@@ -22,6 +22,12 @@ rand_range() {
   LC_CTYPE=C tr -dc "${range}" </dev/urandom | fold -w "${num_chars}" | head -n1 ||:
 }
 
+get_admin_password_metadata(){
+  aws secretsmanager describe-secret \
+    --output json \
+    --secret-id "${ADMIN_PASSWORD_SECRET_NAME}" | tee admin_password_meta.json
+}
+
 echo "Resolving Docker Image to SHA"
 ORIGINAL_CONJUR_IMAGE="${CONJUR_IMAGE}"
 docker pull "${CONJUR_IMAGE}"
@@ -30,27 +36,23 @@ echo "${ORIGINAL_CONJUR_IMAGE} resolved to ${CONJUR_IMAGE}"
 echo "${CONJUR_IMAGE}" > conjur_image
 
 # Find or create the conjur admin password secret in asm
-if aws secretsmanager describe-secret \
-    --output json \
-    --secret-id "${ADMIN_PASSWORD_SECRET_NAME}" > admin_password_meta.json; then
+if get_admin_password_metadata; then
   echo "Secret ${ADMIN_PASSWORD_SECRET_NAME} already exists, not recreating"
-  ADMIN_PASSWORD_ARN="$(jq -r .ARN < admin_password_meta.json )"
-  aws secretsmanager get-secret-value \
-    --secret-id "${ADMIN_PASSWORD_ARN}" \
-    > conjur_admin_password
 else
   echo "Generating And Storing Admin Password"
   # Password Policy: 12-128 characters, 2 uppercase letters, 2 lowercase letters, 1 digit and 1 special character
   ADMIN_PASSWORD="$(rand_range 'a-z' 10)$(rand_range 'A-Z' 10)$(rand_range '[:punct:]' 10)$(rand_range '0-9' 10)"
-  echo "${ADMIN_PASSWORD}" > conjur_admin_password
-
-  ADMIN_PASSWORD_ARN="$(aws secretsmanager create-secret \
+  aws secretsmanager create-secret \
     --name "${ADMIN_PASSWORD_SECRET_NAME}" \
     --secret-string "${ADMIN_PASSWORD}" \
     --output json \
-      | tee create_secret.log \
-      | jq -r .ARN)"
+      | tee create_secret.log
+  unset ADMIN_PASSWORD
+  get_admin_password_metadata
 fi
+# At this point the admin password exists in ASM and metadata has been written
+# to disk so extract the ARN.
+ADMIN_PASSWORD_ARN="$(jq -r .ARN < admin_password_meta.json )"
 
 echo "Templating Parameters File"
 sed \


### PR DESCRIPTION
Previously the conjur admin password for temporary conjur instances
was written to disk. To avoid this unnecessary risk, the conjur admin
password is pulled from AWS Secrets Manager when its required and not
stored.