### PR TITLE
Resolve transient 502s

### DIFF
--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -528,6 +528,13 @@ Resources:
         - !Ref PublicSubnet1
         - !Ref PublicSubnet2
       Type: application
+      LoadBalancerAttributes:
+        # Its important that the idle timeout is lower than the target's timeout (puma).
+        # Otherwise the webserver may timeout a session at the same time the lb is sending
+        # a request, which leads to seemingly random 502 errors. Puma has a default timeout
+        # of 20s, so 10s should be safe here.
+        - Key: idle_timeout.timeout_seconds
+          Value: "10"
   Route53Record:
     Type: 'AWS::Route53::RecordSet'
     Properties:


### PR DESCRIPTION
Its important that the ALB (Application Load Balancer) idle timeout is
lower than the target's timeout (puma). Otherwise the webserver may
timeout a session at the same time the lb is sending a request, which
leads to seemingly random 502 errors. Puma has a default timeout of 20s,
so 10s should be safe for the ALB.

Related: conjurinc/ops#778