### PR TITLE
Allow user to specify a secret for the DB Password

### DIFF
--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -65,6 +65,13 @@ Parameters:
       Amazon Resource Name of an Secrets Manager secret.
       This secret will be used to set the conjur data key.
       If the value is "Generate", then a new conjur data key will be generated.
+  ConjurDBPasswordARN:
+    Type: String
+    Default: "Generate"
+    Description: >-
+      Amazon Resource Name of an Secrets Manager secret.
+      This secret will be used to set the conjur Admin Password.
+      If the value is "Generate", then a new conjur admin password will be generated.
   MinContainers:
     Type: Number
     Default: 2
@@ -129,6 +136,9 @@ Conditions:
   GenerateDataKey: !Equals
     - !Ref ConjurDataKeyARN
     - Generate
+  GenerateDBPassword: !Equals
+    - !Ref ConjurDBPasswordARN
+    - Generate
 
 Resources:
   ConjurDataKey:
@@ -150,6 +160,7 @@ Resources:
   #       PasswordLength: 120
   #       RequireEachIncludedType: true
   ConjurDBPassword:
+    Condition: GenerateDBPassword
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Type: 'AWS::SecretsManager::Secret'
@@ -208,7 +219,10 @@ Resources:
               - 'secretsmanager:GetSecretValue'
             Resource:
               - !Ref ConjurAdminPasswordARN
-              - !Ref ConjurDBPassword
+              - !If
+                - GenerateDBPassword
+                - !Ref ConjurDBPassword
+                - !Ref ConjurDBPasswordARN
               - !If
                 - GenerateDataKey
                 - !Ref ConjurDataKey
@@ -343,7 +357,10 @@ Resources:
                 - !Ref ConjurDataKey
                 - !Ref ConjurDataKeyARN
             - Name: ConjurDBPassword
-              ValueFrom: !Ref ConjurDBPassword
+              ValueFrom: !If
+                - GenerateDBPassword
+                - !Ref ConjurDBPassword
+                - !Ref ConjurDBPasswordARN
             - Name: ConjurAdminPassword
               ValueFrom: !Ref ConjurAdminPasswordARN
       RequiresCompatibilities:
@@ -594,7 +611,10 @@ Resources:
       MasterUserPassword: !Join
         - ''
         - - '{{resolve:secretsmanager:'
-          - !Ref ConjurDBPassword
+          - !If
+            - GenerateDBPassword
+            - !Ref ConjurDBPassword
+            - !Ref ConjurDBPasswordARN
           - '}}'
       DBSubnetGroupName: !Ref DBSubnetGroup
       VPCSecurityGroups:

--- a/scripts/params.template.json
+++ b/scripts/params.template.json
@@ -62,5 +62,9 @@
   {
     "ParameterKey": "ConjurDataKeyARN",
     "ParameterValue": "%CONJUR_DATAKEY_ARN%"
+  },
+  {
+    "ParameterKey": "ConjurDBPasswordARN",
+    "ParameterValue": "%CONJUR_DBPASSWORD_ARN%"
   }
 ]

--- a/scripts/prepare
+++ b/scripts/prepare
@@ -15,6 +15,8 @@ ADMIN_PASSWORD_SECRET_NAME="${ADMIN_PASSWORD_SECRET_NAME:-${STACK_NAME}_adminpas
 ADMIN_PASSWORD_METADATA_FILE="admin_password_meta.json"
 CONJUR_DATAKEY_SECRET_NAME="${CONJUR_DATAKEY_SECRET_NAME:-Generate}"
 CONJUR_DATAKEY_METADATA_FILE="conjur_datakey_meta.json"
+CONJUR_DBPASSWORD_SECRET_NAME="${CONJUR_DBPASSWORD_SECRET_NAME:-Generate}"
+CONJUR_DBPASSWORD_METADATA_FILE="conjur_dbpassword_meta.json"
 PARAMS_TEMPLATE="${PARAMS_TEMPLATE:-${SCRIPTS_DIR}/params.template.json}"
 
 # Generate a random string of characters in a specific character class (according to tr)
@@ -25,16 +27,47 @@ rand_range() {
   LC_CTYPE=C tr -dc "${range}" </dev/urandom | fold -w "${num_chars}" | head -n1 ||:
 }
 
-get_admin_password_metadata(){
+get_secret_metadata(){
+  secret_id="${1}"
+  metadata_file="${2}"
   aws secretsmanager describe-secret \
     --output json \
-    --secret-id "${ADMIN_PASSWORD_SECRET_NAME}" | tee "${ADMIN_PASSWORD_METADATA_FILE}"
+    --secret-id "${secret_id}" | tee "${metadata_file}"
+  rc="${?}"
+
+  if grep -q "DeletedDate" "${metadata_file}"; then
+    echo "${secret_id} exists but is pending deletion so not readable. "
+    echo "Please restore the secret, or specify a different secret name"
+    exit 1
+  fi
+
+  return "${rc}"
 }
 
-get_conjur_datakey_metadata(){
-  aws secretsmanager describe-secret \
-    --output json \
-    --secret-id "${CONJUR_DATAKEY_SECRET_NAME}" | tee "${CONJUR_DATAKEY_METADATA_FILE}"
+get_admin_password_metadata(){
+  get_secret_metadata "${ADMIN_PASSWORD_SECRET_NAME}" "${ADMIN_PASSWORD_METADATA_FILE}"
+}
+
+resolve_secret_name(){
+  secret_name="${1}"
+  metadata_file="${2}"
+
+  # Info prints in this function must be sent to stderr as stdout is expected
+  # to contain the secret ARN or "Generate"
+
+  # If the value is Generate, pass that straight through to the template.
+  # Otherwise resolve the secret name to an ARN.
+  if [[ "${secret_name}" != "Generate" ]]; then
+    get_secret_metadata "${secret_name}" "${metadata_file}" 1>&2
+    ARN="$(jq -r .ARN < "${metadata_file}")"
+    echo "Secret ${secret_name} resolved to ${ARN}" 1>&2
+    # return the arn
+    echo -n "${ARN}"
+  else
+    echo "Passing Generate through to cloudformation template" 1>&2
+    # return Generate
+    echo -n "Generate"
+  fi
 }
 
 echo "Resolving Docker Image to SHA"
@@ -45,14 +78,9 @@ echo "${ORIGINAL_CONJUR_IMAGE} resolved to ${CONJUR_IMAGE}"
 echo "${CONJUR_IMAGE}" > conjur_image
 
 # Find or create the conjur admin password secret in asm
+# The admin password is handled seperately from the db password and datakey as we may have to generate it.
 if get_admin_password_metadata; then
-  if grep -q "DeletedDate" "${ADMIN_PASSWORD_METADATA_FILE}"; then
-    echo "${ADMIN_PASSWORD_SECRET_NAME} exists but is pending deletion so not readable. "
-    echo "Please restore the secret, or specify a different secret name"
-    exit 1
-  else
     echo "Secret ${ADMIN_PASSWORD_SECRET_NAME} already exists, not recreating"
-  fi
 else
   echo "Generating And Storing Admin Password"
   # Password Policy: 12-128 characters, 2 uppercase letters, 2 lowercase letters, 1 digit and 1 special character
@@ -69,16 +97,8 @@ fi
 # to disk so extract the ARN.
 ADMIN_PASSWORD_ARN="$(jq -r .ARN < "${ADMIN_PASSWORD_METADATA_FILE}" )"
 
-# If the value is Generate, pass that straight through to the template.
-# Otherwise resolves the secret name to an ARN.
-if [[ "${CONJUR_DATAKEY_SECRET_NAME}" != "Generate" ]]; then
-  get_conjur_datakey_metadata
-  CONJUR_DATAKEY_ARN="$(jq -r .ARN < "${CONJUR_DATAKEY_METADATA_FILE}" )"
-  echo "CONJUR_DATAKEY secret name ${CONJUR_DATAKEY_SECRET_NAME} resolved to ${CONJUR_DATAKEY_ARN}"
-else
-  echo "CONJUR_DATAKEY=Generate so it will be generated as part of the cloudformaiton template."
-  CONJUR_DATAKEY_ARN="Generate"
-fi
+CONJUR_DATAKEY_ARN="$(resolve_secret_name "${CONJUR_DATAKEY_SECRET_NAME}" "${CONJUR_DATAKEY_METADATA_FILE}")"
+CONJUR_DBPASSWORD_ARN="$(resolve_secret_name "${CONJUR_DBPASSWORD_SECRET_NAME}" "${CONJUR_DBPASSWORD_METADATA_FILE}")"
 
 echo "Templating Parameters File"
 sed \
@@ -86,6 +106,7 @@ sed \
   -e "s/%SUB_DOMAIN%/${SUB_DOMAIN}/" \
   -e "s/%ADMIN_PASSWORD_ARN%/${ADMIN_PASSWORD_ARN}/" \
   -e "s/%CONJUR_DATAKEY_ARN%/${CONJUR_DATAKEY_ARN}/" \
+  -e "s/%CONJUR_DBPASSWORD_ARN%/${CONJUR_DBPASSWORD_ARN}/" \
   -e "s/%DOMAIN_NAME%/${DOMAIN_NAME}/" \
   -e "s/%DOMAIN_ID%/${DOMAIN_ID}/" \
   < "${PARAMS_TEMPLATE}" \


### PR DESCRIPTION
Allow user to specify a secret for the DB Password

This works with the retain secrets option, to allow a new stack to use old secrets.
The user can still have the db password auto generated by not specifying
the param (similar to the ConjurDataKeyARN param)