### PR TITLE
Don't re-encode Data Key

### DIFF
--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -164,6 +164,7 @@ Resources:
       Description: Conjur Data Key
       Name: !Sub '${AWS::StackName}-conjur_key'
       GenerateSecretString:
+        PasswordLength: 32
         ExcludePunctuation: true
   # ConjurAdminPassword:
   #   Type: 'AWS::SecretsManager::Secret'
@@ -328,7 +329,15 @@ Resources:
             - >-
                 set +o history;
                 history -c;
-                export CONJUR_DATA_KEY=$( echo -n $CONJUR_KEY | base64);
+                if [[ "$(base64 -d <<<"${CONJUR_KEY}" |wc -c |sed 's/[^0-9]*//')" == 32 ]]; then
+                  echo "Passing through CONJUR_DATA_KEY without b64 encoding";
+                  export CONJUR_DATA_KEY="${CONJUR_KEY}";
+                elif [[ "$( echo -n "${CONJUR_KEY}" | wc -c | sed 's/[^0-9]*//')" == 32 ]]; then
+                  echo "Base64 encoding the supplied value for CONJUR_DATA_KEY";
+                  export CONJUR_DATA_KEY="$( echo -n "${CONJUR_KEY}" | base64)";
+                else
+                  echo "Invalid CONJUR_KEY must be 32 bytes. Can optionally be base64 encoded.";
+                fi;
                 export DATABASE_URL="postgres://conjur:${ConjurDBPassword}@${DBEndpoint}:${DBPort}/postgres";
                 mkdir -p /puma;
                 openssl req -x509 -newkey rsa:4096 -keyout /puma/key.pem -out /puma/cert.pem -days 365 -subj "/CN=localhost" -nodes;

--- a/scripts/exercise
+++ b/scripts/exercise
@@ -41,6 +41,18 @@ export LOG_GROUP="${STACK_NAME}-conjur-log-group"
 LOG_TAIL_PID="${!}"
 trap 'collect_lb_logs; kill -9 ${LOG_TAIL_PID} || true' EXIT
 
+# Exercise is often run first thing after deploy. Ensure the cluster has settled
+# before getting started.
+for _ in {1..120}; do
+  if curl -k "${BASE_URL}" | grep -i "your conjur server is running"; then
+    echo "Exercise script detects conjur is up, proceeding to exercise."
+    break
+  else
+    echo "Exercise script waiting for conjur to come up"
+    sleep 5
+  fi
+done;
+
 . "${SCRIPTS_DIR}/conjur_login"
 
 # Load Policy


### PR DESCRIPTION
If the datakey is already base64 encoded, don't re-encode it. 