### PR TITLE
Increase RDS max_connections

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
           archiveArtifacts(artifacts: 'params.json')
           archiveArtifacts(artifacts: 'admin_password_meta.json', allowEmptyArchive: true)
           archiveArtifacts(artifacts: 'stack_*.json')
-          archiveArtifacts(artifacts: '*.log', allowEmptyArchive: true)
+          archiveArtifacts(artifacts: '**/*.log', allowEmptyArchive: true)
           sh 'summon -f scripts/secrets.yml scripts/cleanup'
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,6 +40,7 @@ pipeline {
           archiveArtifacts(artifacts: 'admin_password_meta.json', allowEmptyArchive: true)
           archiveArtifacts(artifacts: 'stack_*.json')
           archiveArtifacts(artifacts: '**/*.log', allowEmptyArchive: true)
+          archiveArtifacts(artifacts: 'conjur_git_commit', allowEmptyArchive: true)
           sh 'summon -f scripts/secrets.yml scripts/cleanup'
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,10 @@ pipeline {
     buildDiscarder(logRotator(numToKeepStr: '30'))
   }
 
+  parameters {
+    string(name: 'CONJUR_IMAGE', defaultValue: 'cyberark/conjur:edge', description: 'Conjur image to deploy')
+  }
+
   triggers {
     cron(getDailyCronString())
   }

--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -549,8 +549,47 @@ Resources:
       Protocol: HTTPS
       UnhealthyThresholdCount: 3
       VpcId: !Ref VpcId
+  LBLogsBucket:
+    Type: AWS::S3::Bucket
+    # The bucket is deleted by the cleanup script because cloudformation
+    # can't remove non-empty buckets
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketName: !Sub 'org-conjur-${AWS::StackName}-alb-log-bucket'
+      PublicAccessBlockConfiguration:
+        RestrictPublicBuckets: true
+        IgnorePublicAcls: true
+        BlockPublicPolicy: true
+        BlockPublicAcls: true
+      AccessControl: Private
+      LifecycleConfiguration:
+        Rules:
+          - Id: ExpireLBLogs
+            ExpirationInDays: 60
+            Status: Enabled
+  LogsBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref 'LBLogsBucket'
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: ALBAccessLogs20130930put
+            Effect: Allow
+            Resource: !Join ['', ['arn:aws:s3:::', !Ref 'LBLogsBucket', /, Logs, /AWSLogs/, !Ref 'AWS::AccountId', /*]]
+            Principal:
+              AWS: '127311923021'
+            Action: ['s3:PutObject']
+          - Sid: ALBAccessLogs20130930get
+            Effect: Allow
+            Resource: !Join ['', ['arn:aws:s3:::', !Ref 'LBLogsBucket', /, Logs, /AWSLogs/, !Ref 'AWS::AccountId', /*]]
+            Principal:
+              AWS: !Ref 'AWS::AccountId'
+            Action: ['s3:GetObject']
   LoadBalancer:
     Type: 'AWS::ElasticLoadBalancingV2::LoadBalancer'
+    DependsOn: LogsBucketPolicy
     Properties:
       Name: !Ref 'AWS::StackName'
       SecurityGroups:
@@ -566,6 +605,13 @@ Resources:
         # of 20s, so 10s should be safe here.
         - Key: idle_timeout.timeout_seconds
           Value: "10"
+        - Key: access_logs.s3.enabled
+          Value: "true"
+        - Key: access_logs.s3.bucket
+          Value: !Ref LBLogsBucket
+        - Key: access_logs.s3.prefix
+          Value: Logs
+
   Route53Record:
     Type: 'AWS::Route53::RecordSet'
     Properties:
@@ -653,3 +699,7 @@ Resources:
     Properties:
       LogGroupName: !Sub '${AWS::StackName}-conjur-log-group'
       RetentionInDays: 90
+Outputs:
+  LBLogsBucket:
+    Description: S3 Bucket URL for the LB access logs
+    Value: !GetAtt  LBLogsBucket.Arn

--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -131,6 +131,20 @@ Parameters:
       - 7168
       - 8192
     Description: Memory units to allocate to each container
+  DBMaxConnections:
+    Type: Number
+    Default: 2000
+    MaxValue: 8388607
+    MinValue: 6
+    Description: |
+      Maximum number of simultaneous connections the RDS Postgres Database should accept
+      By default this is the memory of the instance in bytes / some value that depends
+      on the db family (engine, engine version). For conjur-ecs deploy it works out
+      at about 350 with a 4GB RDS instance. A rule of thumb for setting this value
+      is: MaxContainers * ContainerProcesses * PumaThreads * 1.25git
+      The 1.25 is to leave reserved connections for replicas and admins.
+      For the defaults thats 6 * 50 * 5 * 1.25 = 1875, which I've rounded up to 2000.
+      See: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Limits.html#RDS_Limits.MaxConnections
 
 Conditions:
   GenerateDataKey: !Equals
@@ -596,11 +610,21 @@ Resources:
             - '*'
       ListenerArn: !Ref Listener
       Priority: 1
+
+  ConjurDBParameterGroup:
+    Type: AWS::RDS::DBParameterGroup
+    Properties:
+      Description: DB Params for conjur-ecs-deploy RDS Postgres instances
+      Family: postgres10
+      Parameters:
+        max_connections: !Ref DBMaxConnections
+
   ConjurDB:
     Type: 'AWS::RDS::DBInstance'
     DeletionPolicy: Snapshot
     UpdateReplacePolicy: Snapshot
     Properties:
+      DBParameterGroupName: !Ref ConjurDBParameterGroup
       DBName: !Ref 'AWS::StackName'
       Engine: postgres
       EngineVersion: "10.15"

--- a/scripts/cleanup
+++ b/scripts/cleanup
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -uo pipefail
 
 SCRIPTS_DIR="$(dirname "${BASH_SOURCE[0]}")"
 . "${SCRIPTS_DIR}/../bash-lib/init"
@@ -31,10 +31,13 @@ STACK_ARN="$(aws cloudformation describe-stacks \
 echo "Resolved stack name ${STACK_NAME} to ARN: ${STACK_ARN}"
 
 echo "Removing admin password secret"
-aws secretsmanager delete-secret --secret-id "${ADMIN_PASSWORD_SECRET_NAME}"
+aws secretsmanager delete-secret --secret-id "${ADMIN_PASSWORD_SECRET_NAME}" ||:
 
 echo "Storing stack resources"
 aws cloudformation describe-stack-resources --stack-name "${STACK_NAME}" --output json > stack_resources.json
+
+echo "Removing LB Logs S3 Bucket"
+aws s3 rb "s3://org-conjur-${STACK_NAME}-alb-log-bucket" --force ||:
 
 bl_retry_constant 3 600 remove_stack
 

--- a/scripts/conjur_test
+++ b/scripts/conjur_test
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+# Script for finding which conjur change caused a conjur-ecs-deploy problem
+# by testing a range of conjur  (or conjur-dependency) versions.
+
+# The last three functions are the different modes of operation,
+# modify the last line to call the function you are interested in.
+
+# This script assumes conjur is checked out adjacent to conjur-ecs-deploy
+# and that it is being executed from the root of conjur-ecs-deploy.
+
+SCRIPTS_DIR="$(dirname "${BASH_SOURCE[0]}")"
+. "${SCRIPTS_DIR}/../bash-lib/init"
+
+SCRIPTS_DIR="$(bl_abs_path "${SCRIPTS_DIR}")"
+
+# Test images are pushed to dockerhub, set your dockerhub user here. The image
+# used is "pts" because I happened to have a test image already called that.
+# Also it doesn't contain the string Conjur so it won't appear in search results
+# for Conjur.
+DOCKERHUB_USER="${DOCKERHUB_USER:-hughsaunders}"
+
+if [[ "$(basename "$PWD")" != "conjur-ecs-deploy" ]]; then
+    echo "Please run this script from the root of conjur-ecs-deploy"
+    exit 1
+fi
+
+if [[ ! -d ../conjur ]]; then
+    echo "This script assumes conjur is checked out adjacent to conjur-ecs-deploy"
+    exit 1
+fi
+
+if [[ -z "${JENKINS_AUTH}" ]]; then
+    echo "JENKINS_AUTH env var must be set to username:token before running this script"
+    exit 1
+fi
+
+function version_tag() {
+    git rev-parse --short=8 HEAD
+}
+
+run_ecs_build(){
+    IMAGE="${1}"
+    python3 -c 'import requests' || python3 -m pip install requests
+
+    JENKINS_AUTH_TOKEN="${JENKINS_AUTH}" \
+        JENKINS_URL="jenkins.conjur.net" \
+        JENKINS_JOB_NAME="cyberark--conjur-ecs-deploy/job/increasedbconnections-790" \
+        JENKINS_CONJUR_IMAGE="${IMAGE}" \
+        python3 "${SCRIPTS_DIR}/run_jenkins_build.py"
+}
+
+conjur_bisect(){
+    # This function uses git-bisect to test a range of Conjur commits, running
+    # the conjur-ecs-deploy jenkins job against all the commits suggested by
+    # git-bisect.
+    pushd ../conjur
+    git bisect reset
+    git bisect start
+    git checkout v1.11.7
+    git bisect bad
+    git bisect good v1.11.6
+
+    while :; do
+        TAG="$(version_tag)"
+        docker build -t "conjur:${TAG}" .
+        docker tag "conjur:${TAG}" "${DOCKERHUB_USER}/pts:${TAG}"
+        docker push "${DOCKERHUB_USER}/pts:${TAG}"
+        if run_ecs_build "${DOCKERHUB_USER}/pts:${TAG}"; then
+            git bisect good | tee bisect.out
+        else
+            git bisect bad | tee bisect.out
+        fi
+        grep -i "is the first" bisect.out && break
+    done
+}
+
+puma_bisect(){
+
+    # This function is for running conjur-ecs-deploy pipeline against a range of
+    # Puma (a Conjur dependency) versions to see which one introduces the
+    # problem. It uses a python implementation of the bisection algorithm to
+    # test as few version as possible. puma_versions.txt isn't checked in but is
+    # a file containging one gem version per line.
+
+    rm -f ../puma_versions.txt.bisect_state
+    #3.12.5 --> 4.3.8
+    scripts/listbisect.py --file ../puma_versions.txt mark-good --line 3.12.5
+    scripts/listbisect.py --file ../puma_versions.txt mark-bad --line 4.3.8
+
+    pushd ../conjur
+    while :; do
+        test_version="$(../conjur-ecs-deploy/scripts/listbisect.py --file ../puma_versions.txt next-line)"
+        # Exit when bisection is complete
+        if grep 'first bad version is' <<<"${test_version}"; then
+            echo "${test_version}"
+            break
+        fi
+        TAG="${test_version}"
+
+        # Change Gemfile and Gemfile.lock to use test puma version
+        cpv="4.3.8" # current puma version
+        git checkout -- Gemfile
+        git checkout -- Gemfile.lock
+        sed -i -e "s/${cpv}/${test_version}/g" Gemfile
+        sed -i -e "s/${cpv}/${test_version}/g" Gemfile.lock
+
+        docker build -t "conjur:${TAG}" .
+        docker tag "conjur:${TAG}" "${DOCKERHUB_USER}/pts:${TAG}"
+        docker push "${DOCKERHUB_USER}/pts:${TAG}"
+        if run_ecs_build "${DOCKERHUB_USER}/pts:${TAG}"; then
+            echo "first data timeout is good"
+            ../conjur-ecs-deploy/scripts/listbisect.py --file ../puma_versions.txt mark-good --line "${test_version}"
+        else
+            ../conjur-ecs-deploy/scripts/listbisect.py --file ../puma_versions.txt mark-bad --line "${test_version}"
+            echo "first data timeout is bad"
+        fi
+    done
+}
+
+run_custom_conjur(){
+
+    # This function is for testing a single custom conjur version
+    # against conjur-ecs-deploy
+
+    pushd ../conjur
+    TAG="customconjurtest"
+
+    # This function doesn't modify conjur at all, make any
+    # modifications to conjur before running .
+
+    docker build -t "conjur:${TAG}" .
+    docker tag "conjur:${TAG}" "${DOCKERHUB_USER}/pts:${TAG}"
+    docker push "${DOCKERHUB_USER}/pts:${TAG}"
+    if run_ecs_build "${DOCKERHUB_USER}/pts:${TAG}"; then
+        echo "Build Succeded"
+    else
+        echo "Build Failed"
+    fi
+}
+run_custom_conjur

--- a/scripts/exercise
+++ b/scripts/exercise
@@ -99,13 +99,13 @@ echo "Testing serial requests to root url"
 ab 1 root "${BASE_URL}/"
 
 echo "Testing parallel requests to root url"
-ab 2 root "${BASE_URL}/"
+ab 50 root "${BASE_URL}/"
 
 echo "Testing serial variable reads"
 ab 1 "read" -H "$(dconjur authn authenticate -H)" "${BASE_URL}/secrets/conjur/variable/${TEST_VAR}"
 
 echo "Testing parallel variable reads"
-ab 2 "read" -H "$(dconjur authn authenticate -H)" "${BASE_URL}/secrets/conjur/variable/${TEST_VAR}"
+ab 50 "read" -H "$(dconjur authn authenticate -H)" "${BASE_URL}/secrets/conjur/variable/${TEST_VAR}"
 
 echo "Testing serial write"
 date > postfile

--- a/scripts/exercise
+++ b/scripts/exercise
@@ -15,12 +15,30 @@ AB_REQUESTS="500"
 # Relative because it will be used within docker
 TEST_POLICY_FILE="scripts/test_policy.yml"
 
+collect_lb_logs(){
+  echo "Collecting LB Logs"
+  echo "Sleeping 6 minutes to allow async log delivery to complete"
+  sleep 360
+  mkdir -p lblogsync lb_logs
+  # Download all the LB logs from s3 to lblogsync
+  aws s3 sync "s3://org-conjur-${STACK_NAME}-alb-log-bucket" lblogsync
+  # Move all the logs to lb_logs to flatten the hierachy
+  find lblogsync -name "*.log.gz" | while read -r log; do
+    mv "${log}" lb_logs
+  done
+  # Unzip because jenkins doesn't unzip artifacts in the view route
+  # (Jenkins does unzip job logs, but not artifacts)
+  gunzip lb_logs/*
+  rm -rf lblogsync
+}
+
+
 # Main flow
 
 export LOG_GROUP="${STACK_NAME}-conjur-log-group"
 "${SCRIPTS_DIR}"/tail_ecs_logs &
 LOG_TAIL_PID="${!}"
-trap 'kill -9 ${LOG_TAIL_PID} || true' EXIT
+trap 'collect_lb_logs; kill -9 ${LOG_TAIL_PID} || true' EXIT
 
 . "${SCRIPTS_DIR}/conjur_login"
 
@@ -70,6 +88,7 @@ ab(){
     -l \
     -n "${AB_REQUESTS}" \
     -c "${concurrency}" \
+    -v 4 \
     "${@}" \
     | tee "${log}"
   grep '^Failed requests:\s*0' "${log}"

--- a/scripts/listbisect.py
+++ b/scripts/listbisect.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+
+#pybisect
+
+
+# 1 Known good
+# 2
+# 3
+# 4
+# 5 <--- First test, success
+# 6
+# 7 <-- Second test, success
+# 8 <-- Third test, fail
+# 9 <-- Fourth test, success.
+# 10 Known Bad
+
+# result = 10 is the first bad version
+
+# Selector, pick middle version and round down.
+
+import json
+import math
+import os
+
+import click
+
+class BisectFile():
+    def __init__(self, input_path):
+        self.input_path = input_path
+        self.state_path = f"{input_path}.bisect_state"
+        self.state = []
+        self.read_or_create_state_file()
+
+    def write_state_file(self):
+        with open(self.state_path, 'w') as state_file:
+            state_file.write(json.dumps(self.state))
+
+    def read_or_create_state_file(self):
+        if not os.path.exists(self.state_path):
+            with open(self.input_path) as input:
+                self.state = [
+                            {'linenumber': ln,
+                             'content': content,
+                             'status': ''}
+                            for ln, content in enumerate(input.readlines())
+                        ]
+            self.write_state_file()
+
+        with open(self.state_path) as state_file:
+            state = json.load(state_file)
+            # ensure state is sorted by line number on read.
+            state.sort(key=lambda line: line['linenumber'])
+            self.state = state
+
+    def line_number_for_content(self, content):
+        return list(filter(lambda line: line['content'].strip() == content.strip(), self.state))[0]
+
+    def set_line_status(self, content, status):
+        line = self.line_number_for_content(content)
+        line['status'] = status
+        self.state[line['linenumber']] = line
+        self.write_state_file()
+
+    def next_line(self):
+        # Determine which line should be tested next.
+        good_lines = list(filter(lambda l: l['status'] == 'good', self.state))
+        bad_lines = list(filter(lambda l: l['status'] == 'bad', self.state))
+        if len(good_lines) < 1 or len(bad_lines) < 1:
+            raise Exception('At least one good and one bad line must be set'
+                            ' before the next line to test can be calculated')
+
+        # 1 good min_good
+        # 2
+        # 3 good max_good
+        # 4
+        # 5 bad min_bad
+        # 6 bad max_bad
+
+        # 1 bad min_bad
+        # 2
+        # 3 bad max_bad
+        # 4
+        # 5 good min_good
+        # 6 good max_good
+
+        min_good = min([l['linenumber'] for l in good_lines])
+        max_good = max([l['linenumber'] for l in good_lines])
+        min_bad = min([l['linenumber'] for l in bad_lines])
+        max_bad = max([l['linenumber'] for l in bad_lines])
+
+        # print(f"min_good: {min_good}, max_good:{max_good}")
+        # print(f"min_bad: {min_bad}, max_bad:{max_bad}")
+
+        if max_good < min_bad:
+            # good at top of file (find lowest value of min_bad)
+            if max_good + 1 == min_bad:
+                return {'message': "Bisect complete, first bad "
+                        f"version is: {self.state[min_bad]['content'].strip()}"}
+
+            next_index = math.floor((min_bad - max_good)/2) + max_good
+        else:
+            # bad at top
+            if max_bad + 1 == min_good:
+                return {'message': "Bisect complete, first bad "
+                        f"version is: {self.state[max_bad]['content'].strip()}"}
+            next_index = math.floor((min_good - max_bad)/2) + max_bad
+
+        return self.state[next_index]
+
+
+@click.group()
+@click.pass_context
+@click.option('--file', 'input_file', help="Path to input file", required=True)
+def cli(ctx, input_file):
+    """ Program for running bisection on an arbitrary input file
+
+    To start mark one line in a file good and another bad with
+    mark-good and mark-bad. Then request the next line to test
+    with next-line. When the test is complete mark that line,
+    and request the next line until the next-line call announces
+    that bisect is complete.
+
+    Example session:
+
+    \b
+    # Mark initial range
+    $ ./listbisect.py --file test_in.txt mark-good --line 4.3.8
+    $ ./listbisect.py --file test_in.txt mark-bad --line 3.12.5
+    # Request next line, test and mark the result
+    $ ./listbisect.py --file test_in.txt next-line
+    4.3.0
+    $ ./listbisect.py --file test_in.txt mark-bad --line 4.3.0
+    # Repeat until the end
+    $ ./listbisect.py --file test_in.txt next-line
+    4.3.5
+    $ ./listbisect.py --file test_in.txt mark-good --line 4.3.5
+    $ ./listbisect.py --file test_in.txt next-line
+    4.3.3
+    $ ./listbisect.py --file test_in.txt mark-bad --line 4.3.3
+    $ ./listbisect.py --file test_in.txt next-line
+    4.3.4
+    $ ./listbisect.py --file test_in.txt mark-bad --line 4.3.4
+    $ ./listbisect.py --file test_in.txt next-line
+    Bisect complete, first bad version is: 4.3.4
+    Bisect Summary:
+    4.3.8 good
+    4.3.7
+    4.3.6
+    4.3.5 good
+    4.3.4 bad
+    4.3.3 bad
+    4.3.1
+    4.3.0 bad
+    4.2.1
+    4.2.0
+    4.1.1
+    4.1.0
+    4.0.1
+    4.0.0
+    3.12.6
+    3.12.5 bad
+    """
+    ctx.obj = {'bf': BisectFile(input_file)}
+
+@cli.command()
+@click.pass_obj
+@click.option('--line', 'content',
+              help="Contens of the line to be marked as good",
+              required=True)
+def mark_good(ctx, content):
+    """ Mark a line as good """
+    ctx['bf'].set_line_status(content, 'good')
+
+@cli.command()
+@click.pass_obj
+@click.option('--line', 'content',
+              help="Contens of the line to be marked as bad",
+              required=True)
+def mark_bad(ctx, content):
+    """ Mark a line as bad """
+    ctx['bf'].set_line_status(content, 'bad')
+
+@cli.command()
+@click.pass_obj
+def next_line(ctx):
+    """ Show the next line to be tested """
+    next_line = ctx['bf'].next_line()
+    if 'message' in next_line:
+        print(next_line['message'])
+        print('Bisect Summary:')
+        for line in ctx['bf'].state:
+            print(f"{line['content'].strip()} {line['status']}")
+    else:
+        print(next_line['content'].strip())
+
+
+cli()

--- a/scripts/prepare
+++ b/scripts/prepare
@@ -77,6 +77,13 @@ CONJUR_IMAGE="$(docker inspect --format='{{index .RepoDigests 0}}' "${CONJUR_IMA
 echo "${ORIGINAL_CONJUR_IMAGE} resolved to ${CONJUR_IMAGE}"
 echo "${CONJUR_IMAGE}" > conjur_image
 
+# Extract the git commit the conjur git commit from image and store it as a file, so it can be
+# collected as a Jenkins artifact, ignore failure because older conjur images don't contain the commit
+# file.
+echo -n "Conjur container git commit: "
+docker run --rm --entrypoint bash "${CONJUR_IMAGE}" -c 'cat conjur_git_commit' | tee conjur_git_commit ||:
+echo
+
 # Find or create the conjur admin password secret in asm
 # The admin password is handled seperately from the db password and datakey as we may have to generate it.
 if get_admin_password_metadata; then

--- a/scripts/run_jenkins_build.py
+++ b/scripts/run_jenkins_build.py
@@ -1,0 +1,102 @@
+#!/usr/bin/python3
+
+# Based on: https://stackoverflow.com/a/48531874/719362
+
+import os
+import requests
+import re
+import sys
+import json
+import time
+
+# secs for polling Jenkins API
+#
+QUEUE_POLL_INTERVAL = 1
+JOB_POLL_INTERVAL = 15
+OVERALL_TIMEOUT = 36006
+
+# job specifics: should be passed in
+auth_token = os.environ['JENKINS_AUTH_TOKEN']
+jenkins_uri = os.environ['JENKINS_URL']
+job_name = os.environ['JENKINS_JOB_NAME']
+conjur_image = os.environ['JENKINS_CONJUR_IMAGE']
+
+# start the build
+#
+start_build_url = \
+    f"https://{auth_token}@{jenkins_uri}/job/{job_name}/buildWithParameters"
+r = requests.post(start_build_url, data={"CONJUR_IMAGE": conjur_image})
+
+if r.status_code != 201:
+    print(f"Error occurred, status code: {r.status_code}")
+    print("Headers:")
+    print(json.dumps(dict(r.headers), indent=4))
+    print("Response:")
+    print(r.text)
+
+# from return headers get job queue location
+#
+m = re.match(r"http.+(queue.+)\/", r.headers['Location'])
+if not m:
+    # To Do: handle error
+    print("Jenkins did not respond with the "
+          "queue location when a build was requested")
+    sys.exit(1)
+
+# poll the queue looking for job to start
+#
+queue_id = m.group(1)
+job_info_url = f'http://{auth_token}@{jenkins_uri}/{queue_id}/api/json'
+elapsed_time = 0
+print(f'{time.ctime()} Job {job_name} added to queue: {job_info_url}')
+while True:
+    queue_info_response = requests.get(job_info_url)
+    queue_info = queue_info_response.json()
+    task = queue_info['task']['name']
+    try:
+        job_id = queue_info['executable']['number']
+        break
+    except Exception:
+        print(f"no job ID yet for build: {task}")
+        time.sleep(QUEUE_POLL_INTERVAL)
+        elapsed_time += QUEUE_POLL_INTERVAL
+
+    if (elapsed_time % (QUEUE_POLL_INTERVAL * 10)) == 0:
+        print(f"{time.ctime()}: Job {job_name} "
+              "not started yet from {queue_id}")
+
+# poll job status waiting for a result
+#
+job_url = (f'http://{auth_token}@{jenkins_uri}'
+           f'/job/{job_name}/{job_id}/api/json')
+start_epoch = int(time.time())
+while True:
+    print("{}: Job started URL: {}".format(time.ctime(), job_url))
+    job = requests.get(job_url).json()
+    result = job['result']
+    # Some jobs set a result before they complete. The result might change,
+    # so wait till the build is complete before reading the result.
+    if job['building']:
+        print(f"{time.ctime()}: Job: {job_name}#{job_id} still building. "
+              f"Polling again in {JOB_POLL_INTERVAL} secs")
+    else:
+        if result == 'SUCCESS':
+            # Do success steps
+            print(f"{time.ctime()}: Job: {job_name}#{job_id} Status: {result}")
+            break
+        elif result == 'FAILURE':
+            # Do failure steps
+            print(f"{time.ctime()}: Job: {job_name}#{job_id} Status: {result}")
+            sys.exit(1)
+        elif result == 'ABORTED':
+            # Do aborted steps
+            print(f"{time.ctime()}: Job: {job_name}#{job_id} Status: {result}")
+            sys.exit(1)
+
+    cur_epoch = int(time.time())
+    if (cur_epoch - start_epoch) > OVERALL_TIMEOUT:
+        print(f"{time.ctime()}: Build didn't complete before timeout"
+              f" of {OVERALL_TIMEOUT} secs")
+        sys.exit(1)
+
+    time.sleep(JOB_POLL_INTERVAL)


### PR DESCRIPTION
After sustained running, the RDS DB connection limit was hit leading to errors from non-ecs clients attempting to get DB connections. This was due
to a misreading of the RDS docs that lead me to think max_connections
was always atleast 5000. The current max connections for a 4gb instance
is ~350. This commit makes the value configurable but sets the default
at 2000 which fits with the other defaults.

Related: conjurinc/ops#790