### PR TITLE
Add Prefixlist parameter

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,6 +28,7 @@ pipeline {
     stage('Smoke Test'){
       environment {
         STACK_NAME = "ecsdeployci${BRANCH_NAME.replaceAll("[^A-Za-z0-9]", "").toLowerCase().take(6)}${BUILD_NUMBER}"
+        ELB_PREFIXLIST_ID="pl-05978d3ff26527d2a"
       }
       steps {
         sh 'summon -f scripts/secrets.yml scripts/prepare'

--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -145,6 +145,20 @@ Parameters:
       The 1.25 is to leave reserved connections for replicas and admins.
       For the defaults thats 6 * 50 * 5 * 1.25 = 1875, which I've rounded up to 2000.
       See: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Limits.html#RDS_Limits.MaxConnections
+  ElbPrefixListId:
+    Type: String
+    Default: ''
+    Description: |
+      This prefix list will be added to the elb security group, so only requests with a source IP that matches
+      an entry in the prefix list will be allowed.
+  ElbCidr:
+    Type: String
+    Default: '0.0.0.0/0'
+    Description: |
+      Requests from this CIDR will be allowed to access the load balancer. If you wish to restrict
+      access to this conjur instance by IP, please override this CIDR. For finer control, specify
+      a prefix list id in ElbPrefixListId. Note that if ElbPrefixListId is specified then this
+      parameter is ignored.
   ConjurAuthenticators:
     Type: String
     Description: |
@@ -159,6 +173,7 @@ Conditions:
   GenerateDBPassword: !Equals
     - !Ref ConjurDBPasswordARN
     - Generate
+  ElbUsePrefixList: !Not [!Equals [!Ref ElbPrefixListId, ""]]
 
 Resources:
   ConjurDataKey:
@@ -223,7 +238,8 @@ Resources:
         - IpProtocol: tcp
           FromPort: 443
           ToPort: 443
-          CidrIp: 0.0.0.0/0
+          CidrIp: !If [ElbUsePrefixList, !Ref "AWS::NoValue", !Ref ElbCidr]
+          SourcePrefixListId: !If [ElbUsePrefixList, !Ref ElbPrefixListId, !Ref "AWS::NoValue"]
   Cluster:
     Type: 'AWS::ECS::Cluster'
     Properties:

--- a/scripts/params.template.json
+++ b/scripts/params.template.json
@@ -90,6 +90,13 @@
   {
     "ParameterKey": "ConjurAuthenticators",
     "ParameterValue": "%CONJUR_AUTHENTICATORS%"
+  },
+  {
+    "ParameterKey": "ElbPrefixListId",
+    "ParameterValue": "%ELB_PREFIXLIST_ID%"
+  },
+  {
+    "ParameterKey": "ElbCidr",
+    "ParameterValue": "%ELB_CIDR%"
   }
-  
 ]

--- a/scripts/prepare
+++ b/scripts/prepare
@@ -27,6 +27,8 @@ CONTAINER_MEMORY="${CONTAINER_MEMORY:-8192}"
 MAX_CONTAINERS="${MAX_CONTAINERS:-6}"
 MIN_CONTAINERS="${MIN_CONTAINERS:-2}"
 CONJUR_AUTHENTICATORS="${CONJUR_AUTHENTICATORS:-}"
+ELB_PREFIXLIST_ID="${ELB_PREFIXLIST_ID:-}"
+ELB_CIDR="${ELB_CIDR:-}"
 
 # Generate a random string of characters in a specific character class (according to tr)
 # Used to generate conjur admin password if the secret doesn't already exist.
@@ -134,5 +136,7 @@ sed \
   -e "s/%CONTAINER_MEMORY%/${CONTAINER_MEMORY}/" \
   -e "s/%MAX_CONTAINERS%/${MAX_CONTAINERS}/" \
   -e "s/%MIN_CONTAINERS%/${MIN_CONTAINERS}/" \
+  -e "s/%ELB_PREFIXLIST_ID%/${ELB_PREFIXLIST_ID}/" \
+  -e "s/%ELB_CIDR%/${ELB_CIDR}/" \
   < "${PARAMS_TEMPLATE}" \
   > params.json


### PR DESCRIPTION
This allows a user to specify a prefix list, which is a list of
subnets. Only requests from these subnets will be allowed by
the public load balancer.

Related: conjurinc/ops#874