### PR TITLE
CNJR-1442 Upgrade Postgres

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
     }
     stage('Smoke Test'){
       environment {
-        STACK_NAME = "ecsdeployci${BRANCH_NAME.replaceAll("[^A-Za-z0-9]", "").take(6)}${BUILD_NUMBER}"
+        STACK_NAME = "ecsdeployci${BRANCH_NAME.replaceAll("[^A-Za-z0-9]", "").toLowerCase().take(6)}${BUILD_NUMBER}"
       }
       steps {
         sh 'summon -f scripts/secrets.yml scripts/prepare'

--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -672,7 +672,7 @@ Resources:
     Type: AWS::RDS::DBParameterGroup
     Properties:
       Description: DB Params for conjur-ecs-deploy RDS Postgres instances
-      Family: postgres10
+      Family: postgres15
       Parameters:
         max_connections: !Ref DBMaxConnections
 
@@ -684,7 +684,7 @@ Resources:
       DBParameterGroupName: !Ref ConjurDBParameterGroup
       DBName: !Ref 'AWS::StackName'
       Engine: postgres
-      EngineVersion: "10.20"
+      EngineVersion: "15.3"
       AllocatedStorage: "20"
       StorageType: gp2
       DBInstanceClass: db.t3.medium


### PR DESCRIPTION
Postgres 11-13 had issues with scram-sha-256 password encryption, it used a low level call that wasn't approved in ssl fips mode. MD5 also isn't allowed by fips so there were effectively no fips compatible password ciphers.

This commit upgrades straight from 10-15. 15 is used internally in Conjur Enterprise, so is known to be supported.