### PR TITLE
CNJR-2493: Allow authenticators to be configured

### DIFF
--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -145,6 +145,12 @@ Parameters:
       The 1.25 is to leave reserved connections for replicas and admins.
       For the defaults thats 6 * 50 * 5 * 1.25 = 1875, which I've rounded up to 2000.
       See: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Limits.html#RDS_Limits.MaxConnections
+  ConjurAuthenticators:
+    Type: String
+    Description: |
+      Comma separated list of authenticators (as defined in policy), without the conjur/ prefix.
+      Eg for an authenticator policy conjur:policy:conjur/authn-oidc/cybr-identity,
+      ConjurAuthenticatators="authn-oidc/cybr-identity"
 
 Conditions:
   GenerateDataKey: !Equals
@@ -373,6 +379,8 @@ Resources:
               Value: !Ref ContainerProcesses
             - Name: RAILS_MAX_THREADS
               Value: !Ref PumaThreads
+            - Name: CONJUR_AUTHENTICATORS
+              Value: !Ref ConjurAuthenticators
           Secrets:
             - Name: CONJUR_KEY
               ValueFrom: !If

--- a/scripts/params.template.json
+++ b/scripts/params.template.json
@@ -86,5 +86,10 @@
   {
     "ParameterKey": "ConjurDBPasswordARN",
     "ParameterValue": "%CONJUR_DBPASSWORD_ARN%"
+  },
+  {
+    "ParameterKey": "ConjurAuthenticators",
+    "ParameterValue": "%CONJUR_AUTHENTICATORS%"
   }
+  
 ]

--- a/scripts/prepare
+++ b/scripts/prepare
@@ -26,6 +26,7 @@ CONTAINER_CPU="${CONTAINER_CPU:-2048}"
 CONTAINER_MEMORY="${CONTAINER_MEMORY:-8192}"
 MAX_CONTAINERS="${MAX_CONTAINERS:-6}"
 MIN_CONTAINERS="${MIN_CONTAINERS:-2}"
+CONJUR_AUTHENTICATORS="${CONJUR_AUTHENTICATORS:-}"
 
 # Generate a random string of characters in a specific character class (according to tr)
 # Used to generate conjur admin password if the secret doesn't already exist.
@@ -118,6 +119,7 @@ CONJUR_DBPASSWORD_ARN="$(resolve_secret_name "${CONJUR_DBPASSWORD_SECRET_NAME}" 
 echo "Templating Parameters File"
 sed \
   -e "s+%CONJUR_IMAGE%+${CONJUR_IMAGE}+" \
+  -e "s+%CONJUR_AUTHENTICATORS%+${CONJUR_AUTHENTICATORS}+" \
   -e "s/%SUB_DOMAIN%/${SUB_DOMAIN}/" \
   -e "s/%ADMIN_PASSWORD_ARN%/${ADMIN_PASSWORD_ARN}/" \
   -e "s/%CONJUR_DATAKEY_ARN%/${CONJUR_DATAKEY_ARN}/" \


### PR DESCRIPTION
Previously conjur-ecs deploy did not allow a user to specify authenticators that should be enabled. This commit adds an environment variable (CONJUR_AUTHENTICATORS) which is read by the prepare script, and passed to cloudformation via the params file. The cloudformation template then sets this variable as an environment entry for the conjur container so conjur can read the list of allowed authenticators.
